### PR TITLE
Configure Filecoin Calibration testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ All services are exposed through a consistent interface of MCP tools and resourc
 - Goerli
 - Holesky
 - Flow Testnet
+- Filecoin Calibration
 - Lumia Testnet
 
 ## 🛠️ Prerequisites

--- a/src/core/chains.ts
+++ b/src/core/chains.ts
@@ -56,7 +56,8 @@ import {
   celoAlfajores,
   goerli,
   holesky,
-  flowTestnet
+  flowTestnet,
+  filecoinCalibration
 } from 'viem/chains';
 
 // Default configuration values
@@ -122,6 +123,7 @@ export const chainMap: Record<number, Chain> = {
   5: goerli,
   17000: holesky,
   545: flowTestnet,
+  314159: filecoinCalibration,
 };
 
 // Map network names to chain IDs for easier reference
@@ -215,6 +217,7 @@ export const networkNameMap: Record<string, number> = {
   'goerli': 5,
   'holesky': 17000,
   'flow-testnet': 545,
+  'filecoin-calibration': 314159,
 };
 
 // Map chain IDs to RPC URLs
@@ -276,6 +279,7 @@ export const rpcUrlMap: Record<number, string> = {
   5: 'https://rpc.ankr.com/eth_goerli',
   17000: 'https://ethereum-holesky.publicnode.com',
   545: 'https://testnet.evm.nodes.onflow.org',
+  314159: 'https://api.calibration.node.glif.io/rpc/v1',
 };
 
 /**


### PR DESCRIPTION
This pull request introduces support for the Filecoin Calibration network by updating documentation and extending the chain configuration in the codebase. The most important changes include adding the Filecoin Calibration network to the list of supported networks and updating various mappings in the chain configuration file to include its details.

### Documentation Update:
* Added "Filecoin Calibration" to the list of supported networks in the `README.md` file.

### Chain Configuration Updates:
* Added `filecoinCalibration` to the list of imported chains in `src/core/chains.ts`.
* Updated `chainMap` to include the chain ID and configuration for Filecoin Calibration (`314159`).
* Updated `networkNameMap` to map the network name `filecoin-calibration` to its chain ID (`314159`).
* Updated `rpcUrlMap` to include the RPC URL for Filecoin Calibration (`https://api.calibration.node.glif.io/rpc/v1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Filecoin Calibration testnet network.
- **Documentation**
  - Updated documentation to list Filecoin Calibration as a supported test network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->