### PR TITLE
feat: Add XLayer mainnet and testnet support

### DIFF
--- a/src/core/chains.ts
+++ b/src/core/chains.ts
@@ -32,7 +32,8 @@ import {
   aurora,
   canto,
   flowMainnet,
-  
+  xLayer,
+
   // Testnets
   sepolia,
   optimismSepolia,
@@ -57,7 +58,8 @@ import {
   goerli,
   holesky,
   flowTestnet,
-  filecoinCalibration
+  filecoinCalibration,
+  xLayerTestnet,
 } from 'viem/chains';
 
 // Default configuration values
@@ -98,7 +100,8 @@ export const chainMap: Record<number, Chain> = {
   1313161554: aurora,
   7700: canto,
   747: flowMainnet,
-  
+  196: xLayer,
+
   // Testnets
   11155111: sepolia,
   11155420: optimismSepolia,
@@ -124,6 +127,7 @@ export const chainMap: Record<number, Chain> = {
   17000: holesky,
   545: flowTestnet,
   314159: filecoinCalibration,
+  1952: xLayerTestnet,
 };
 
 // Map network names to chain IDs for easier reference
@@ -172,7 +176,8 @@ export const networkNameMap: Record<string, number> = {
   'aurora': 1313161554,
   'canto': 7700,
   'flow': 747,
-  
+  'xlayer': 196,
+
   // Testnets
   'sepolia': 11155111,
   'optimism-sepolia': 11155420,
@@ -218,6 +223,7 @@ export const networkNameMap: Record<string, number> = {
   'holesky': 17000,
   'flow-testnet': 545,
   'filecoin-calibration': 314159,
+  'xlayer-testnet': 1952,
 };
 
 // Map chain IDs to RPC URLs
@@ -254,7 +260,8 @@ export const rpcUrlMap: Record<number, string> = {
   1313161554: 'https://mainnet.aurora.dev',
   7700: 'https://canto.gravitychain.io',
   747: 'https://mainnet.evm.nodes.onflow.org',
-  
+  196: 'https://xlayerrpc.okx.com',
+
   // Testnets
   11155111: 'https://sepolia.drpc.org',
   11155420: 'https://sepolia.optimism.io',
@@ -280,6 +287,7 @@ export const rpcUrlMap: Record<number, string> = {
   17000: 'https://ethereum-holesky.publicnode.com',
   545: 'https://testnet.evm.nodes.onflow.org',
   314159: 'https://api.calibration.node.glif.io/rpc/v1',
+  1952: 'https://xlayertestrpc.okx.com',
 };
 
 /**


### PR DESCRIPTION
This pull request adds support for the xLayer and xLayer Testnet blockchains throughout the `src/core/chains.ts` file. The changes ensure that both mainnet and testnet variants of xLayer are integrated into the application's chain configuration, network name mapping, and RPC URL resolution.

**xLayer and xLayer Testnet Integration:**

* Added `xLayer` and `xLayerTestnet` imports from `viem/chains` and included them in the `chainMap` for their respective chain IDs (`196` for xLayer, `1952` for xLayer Testnet). [[1]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28R35) [[2]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28L60-R62) [[3]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28R103) [[4]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28R130)
* Updated `networkNameMap` to map `'xlayer'` and `'xlayer-testnet'` to their corresponding chain IDs. [[1]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28R179) [[2]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28R226)
* Added RPC URLs for both xLayer (`https://xlayerrpc.okx.com`) and xLayer Testnet (`https://xlayertestrpc.okx.com`) in the `rpcUrlMap`. [[1]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28R263) [[2]](diffhunk://#diff-45a4fd22cd57b58f5a68b41e77af07f976745a6ddf6a8b3b2b3095b63394ce28R290)