### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,3 +667,8 @@ To modify or extend the server:
 ## 📄 License
 
 This project is licensed under the terms of the [MIT License](./LICENSE).
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mcpdotdirect-evm-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/mcpdotdirect-evm-mcp-server).